### PR TITLE
Port caml-types-time to future Emacs

### DIFF
--- a/caml-types.el
+++ b/caml-types.el
@@ -595,9 +595,11 @@ corresponding .annot file."
   nil)
 
 (defun caml-types-time ()
-  (let ((time (current-time)))
+  (if (fboundp 'time-convert)
+      (mod (car (time-convert nil 1000)) 1000000)
+    (let ((time (current-time)))
      (+ (* (mod (cadr time) 1000) 1000)
-                  (/ (cadr (cdr time)) 1000))))
+                  (/ (cadr (cdr time)) 1000)))))
 
 (defun caml--release-event-p (original event)
   (and (equal (event-basic-type original) (event-basic-type event))


### PR DESCRIPTION
* caml-types.el (caml-types-time):
Do not assume Emacs timestamp format, which is slated to change in
future versions.  Instead, use time-convert to convert to milliseconds
since the epoch modulo 1000000.  This is simpler and less glitchy than
the old version anyway (millseconds since the epoch modulo 1000, plus
1000 times seconds since the epoch modulo 65536 modulo 1000).
This code uses fboundp to be portable to Emacs 26 and earlier,
and can be simplified once we can assume Emacs 27.