### PR TITLE
Fix the bug of imenu index function

### DIFF
--- a/caml.el
+++ b/caml.el
@@ -644,17 +644,17 @@ See `imenu-create-index-function'."
     ;; build menu
     (mapc
      (lambda (pair)
-       (if (symbol-value (cdr pair))
+       (if (not (null (cdr pair)))
            (setq menu-alist
                  (cons
                   (cons (car pair)
-                        (sort (symbol-value (cdr pair)) 'imenu--sort-by-name))
+                        (sort (cdr pair) 'imenu--sort-by-name))
                   menu-alist))))
-     '(("Values" . value-alist)
-       ("Types" . type-alist)
-       ("Modules" . module-alist)
-       ("Methods" . method-alist)
-       ("Classes" . class-alist)))
+     `(("Values" . ,value-alist)
+       ("Types" . ,type-alist)
+       ("Modules" . ,module-alist)
+       ("Methods" . ,method-alist)
+       ("Classes" . ,class-alist)))
     (if all-alist (setq menu-alist (cons (cons "Index" all-alist) menu-alist)))
     (imenu-progress-message prev-pos 100 t)
     menu-alist))


### PR DESCRIPTION
### How to reproduce this issue

1. Launch plain emacs by `emacs -Q -L .`
1. Load caml.el
1. Crate a new ocaml file by `C-x C-f foo.ml`
1. `M-x caml-mode`
1. `M-x imenu`

Then Emacs throws an exception. `if: Symbol’s value as variable is void: value-alist`

### Changes

Don't use `symbol-name` for local variables and use those values directly instead

`symbol-value` document says as below and we should use `symbol-value` for global variables, not local variables when `lexical-binding` is non-nil.

> symbol-value is a built-in function in ‘C source code’.
>
> (symbol-value SYMBOL)
> 
> Return SYMBOL’s value.  Error if that is void.
> Note that if ‘lexical-binding’ is in effect, this returns the
> global value outside of any lexical scope.

### Reference

- https://github.com/emacs-mirror/emacs/blob/emacs-27.2/src/data.c#L1278-L1280
