### PR TITLE
fix(caml.el): to comply with Emacs' manual D.2 Key Binding Conventions

### DIFF
--- a/caml-help.el
+++ b/caml-help.el
@@ -839,11 +839,11 @@ buffer positions."
 ;  (boundp 'caml-mode-map)
 ;  (keymapp caml-mode-map)
 ;  (progn
-;    (define-key caml-mode-map [?\C-c?i] 'ocaml-add-path)
-;    (define-key caml-mode-map [?\C-c?]] 'ocaml-close-module)
-;    (define-key caml-mode-map [?\C-c?[] 'ocaml-open-module)
-;    (define-key caml-mode-map [?\C-c?\C-h] 'caml-help)
-;    (define-key caml-mode-map [?\C-c?\t] 'caml-complete)
+;    (define-key caml-mode-map [?\C-c?i] #'ocaml-add-path)
+;    (define-key caml-mode-map [?\C-c?]] #'ocaml-close-module)
+;    (define-key caml-mode-map [?\C-c?[] #'ocaml-open-module)
+;    (define-key caml-mode-map [?\C-h?.] #'caml-help)
+;    (define-key caml-mode-map [?\C-c?\t] #'caml-complete)
 ;    (let ((map (lookup-key caml-mode-map [menu-bar caml])))
 ;      (and
 ;       (keymapp map)

--- a/caml.el
+++ b/caml.el
@@ -315,7 +315,7 @@ have `caml-electric-indent' on, which see.")
     (define-key map [?\C-c?i] #'ocaml-add-path)
     (define-key map [?\C-c?\]] #'ocaml-close-module)
     (define-key map [?\C-c?\[] #'ocaml-open-module)
-    (define-key map [?\C-c?\C-h] #'caml-help)
+    (define-key map [?\C-h?.] #'caml-help)
     (define-key map [?\C-c?\t] #'caml-complete)
     ;; others
     (define-key map "\C-cb" #'caml-insert-begin-form)


### PR DESCRIPTION
(https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html)

Unbind <kbd>C-c C-h</kbd> and bind <kbd>C-h .</kbd> instead.

Related: https://github.com/ocaml/merlin/issues/1386#issuecomment-1701567716

Cc @Chris00 and @monnier FYI