### PR TITLE
Makefile: allow backslashes in INSTALL_DIR (for Windows)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,24 +73,24 @@ install-el:
 
 install:
 	@echo "Installing in $(INSTALL_DIR)..."
-	$(INSTALL_MKDIR) $(INSTALL_DIR)
-	$(INSTALL_DATA) $(FILES) $(INSTALL_DIR)
+	$(INSTALL_MKDIR) "$(INSTALL_DIR)"
+	$(INSTALL_DATA) $(FILES) "$(INSTALL_DIR)"
 	if [ -z "$(NOCOMPILE)" ]; then \
-	  cd $(INSTALL_DIR); $(EMACS) --batch --eval '$(COMPILECMD)'; \
+	  cd "$(INSTALL_DIR)"; $(EMACS) --batch --eval '$(COMPILECMD)'; \
 	fi
 
 uninstall:
-	cd $(INSTALL_DIR) && $(INSTALL_RM_R) $(FILES) $(FILES:.el=.elc)
+	cd "$(INSTALL_DIR)" && $(INSTALL_RM_R) $(FILES) $(FILES:.el=.elc)
 
 ocamltags:	ocamltags.in
 	sed -e 's:@EMACS@:$(EMACS):' ocamltags.in >ocamltags
 	chmod a+x ocamltags
 
 install-ocamltags: ocamltags
-	$(INSTALL_DATA) ocamltags $(INSTALL_BIN)/ocamltags
+	$(INSTALL_DATA) ocamltags "$(INSTALL_BIN)"/ocamltags
 
 uninstall-ocamltags:
-	$(INSTALL_RM_R) $(INSTALL_BIN)/ocamltags
+	$(INSTALL_RM_R) "$(INSTALL_BIN)"/ocamltags
 
 tarball: $(TARBALL)
 $(TARBALL): $(DIST_FILES)


### PR DESCRIPTION
`INSTALL_DIR` will typically contain backslashes under Windows, so it needs to be quoted so that it is correctly handled by the shell. Fixes:

```
The following actions will be performed:
=== recompile 1 package
  ↻ caml-mode 4.9

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
⬇ retrieved caml-mode.4.9  (cached)
[WARNING] package uninstall script failed at C:\cygwin64\bin\make.exe uninstall INSTALL_DIR=C:\Users\nojebar\dune\_opam\share/emacs/site-lisp:
          # context     2.2.1 | win32/x86_64 | ocaml.5.2.0 | https://opam.ocaml.org#f45685efec14dffa74b060edb3fcc572bfcea34c
          # path        ~\dune\_opam\.opam-switch\remove\caml-mode.4.9
          # command     C:\cygwin64\bin\make.exe uninstall INSTALL_DIR=C:\Users\nojebar\dune\_opam\share/emacs/site-lisp
          # exit-code   2
          # env-file    ~\AppData\Local\opam\log\caml-mode-27228-bceeb9.env
          # output-file ~\AppData\Local\opam\log\caml-mode-27228-bceeb9.out
          ### output ###
          # cd C:\Users\nojebar\dune\_opam\share/emacs/site-lisp && rm -f -r caml-font.el caml.el camldebug.el inf-caml.el caml-help.el caml-types.el caml-font.elc caml.elc camldebug.elc inf-caml.elc caml-help.elc caml-types.elc
          # /bin/sh: line 1: cd: C:Usersnojebardune_opamshare/emacs/site-lisp: No such file or directory
          # make: *** [Makefile:83: uninstall] Error 1

∗ installed caml-mode.4.9
Done.
```